### PR TITLE
Fix FK metadata in papers table

### DIFF
--- a/relbench/datasets/arxiv.py
+++ b/relbench/datasets/arxiv.py
@@ -62,7 +62,7 @@ class ArxivDataset(Dataset):
         tables = {
             "papers": Table(
                 df=pd.DataFrame(papers),
-                fkey_col_to_pkey_table={},
+                fkey_col_to_pkey_table={"Primary_Category_ID": "categories"},
                 pkey_col="Paper_ID",
                 time_col="Submission_Date",
             ),


### PR DESCRIPTION
  This PR fixes #374, i.e the missing rel-arxiv foreign key metadata for papers.Primary_Category_ID.