### PR TITLE
Fail the publish job when the push to main is rejected

### DIFF
--- a/.github/workflows/leaderboard_publish.yml
+++ b/.github/workflows/leaderboard_publish.yml
@@ -65,9 +65,11 @@ jobs:
           git add leaderboard/
           git commit -m "Leaderboard entry from #${{ github.event.issue.number }}"
           for i in 1 2 3; do
-            git push && break
+            git push && exit 0
             git pull --rebase && sleep $i
           done
+          echo "push to main failed after 3 attempts" >&2
+          exit 1
 
       - name: Close issue
         env:


### PR DESCRIPTION
The retry loop's last command was `git pull --rebase && sleep $i`, so after three rejected pushes the step still exited 0. The job reported success, the issue was closed, and no leaderboard entry was ever written (see #380, #381).